### PR TITLE
feat(htg): Phase 3 - SrtmService with LRU Caching

### DIFF
--- a/htg/Cargo.toml
+++ b/htg/Cargo.toml
@@ -12,6 +12,7 @@ readme = "../README.md"
 
 [dependencies]
 memmap2 = "0.9"
+moka = { version = "0.12", features = ["sync"] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/htg/src/lib.rs
+++ b/htg/src/lib.rs
@@ -6,11 +6,33 @@
 //! ## Features
 //!
 //! - **Fast**: Memory-mapped I/O for instant data access
-//! - **Memory Efficient**: Only loads tiles on demand
+//! - **Memory Efficient**: LRU cache limits memory usage
 //! - **Automatic Detection**: Determines tile resolution (SRTM1/SRTM3) from file size
 //! - **Offline**: Works with local `.hgt` files, no internet required
 //!
 //! ## Quick Start
+//!
+//! The easiest way to use htg is through [`SrtmService`], which handles tile
+//! loading and caching automatically:
+//!
+//! ```ignore
+//! use htg::SrtmService;
+//!
+//! // Create service with up to 100 cached tiles
+//! let service = SrtmService::new("/path/to/hgt/files", 100);
+//!
+//! // Query elevation - tile loading is automatic
+//! let elevation = service.get_elevation(35.6762, 139.6503)?; // Tokyo
+//! println!("Elevation: {}m", elevation);
+//!
+//! // Check cache performance
+//! let stats = service.cache_stats();
+//! println!("Cache hit rate: {:.1}%", stats.hit_rate() * 100.0);
+//! ```
+//!
+//! ## Low-Level API
+//!
+//! For more control, you can work with tiles directly:
 //!
 //! ```ignore
 //! use htg::{SrtmTile, filename};
@@ -22,7 +44,6 @@
 //! // Load the tile and query elevation
 //! let tile = SrtmTile::from_file(&format!("/data/{}", filename))?;
 //! let elevation = tile.get_elevation(35.5, 138.7)?;
-//! println!("Elevation: {}m", elevation);
 //! ```
 //!
 //! ## SRTM Data Format
@@ -43,8 +64,10 @@
 
 pub mod error;
 pub mod filename;
+pub mod service;
 pub mod tile;
 
 // Re-export main types at crate root for convenience
 pub use error::{Result, SrtmError};
+pub use service::{CacheStats, SrtmService};
 pub use tile::{SrtmResolution, SrtmTile, VOID_VALUE};


### PR DESCRIPTION
## Summary

This PR implements Phase 3 of the htg library - the caching layer with `SrtmService`.

### Changes

- **Dependencies**: Added `moka` (0.12) for thread-safe LRU cache
- **SrtmService** (`htg/src/service.rs`):
  - High-level interface for elevation queries
  - Automatic tile loading and filename detection
  - LRU cache with configurable size
  - Thread-safe with atomic hit/miss counters
- **CacheStats**: Track cache performance with `hit_rate()` calculation
- **Cache Management**:
  - `invalidate_tile()` - remove specific tile
  - `clear_cache()` - clear all tiles
  - `cache_capacity()` - get max cache size
- **Documentation**: Updated lib.rs with SrtmService quick start example

### API

```rust
use htg::SrtmService;

// Create service with up to 100 cached tiles
let service = SrtmService::new("/path/to/hgt/files", 100);

// Query elevation - automatic tile loading
let elevation = service.get_elevation(35.6762, 139.6503)?;

// Check cache performance
let stats = service.cache_stats();
println!("Hit rate: {:.1}%", stats.hit_rate() * 100.0);
```

### Tests

```
running 24 tests
test service::tests::test_service_basic ... ok
test service::tests::test_cache_hit ... ok
test service::tests::test_multiple_tiles ... ok
test service::tests::test_invalid_coordinates ... ok
test service::tests::test_missing_file ... ok
test service::tests::test_cache_stats ... ok
test service::tests::test_clear_cache ... ok
test service::tests::test_cache_capacity ... ok
... (+ 16 existing tests)

test result: ok. 24 passed; 0 failed
```

## Test Plan

- [x] All unit tests pass (`cargo test --all`)
- [x] Code formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --all -- -D warnings`)
- [ ] Manual test with real .hgt file (optional)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)