### PR TITLE
ci: add GitHub Actions workflow for tests and formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Clippy (no features)
+        run: cargo clippy --workspace -- -D warnings
+      - name: Clippy (download feature)
+        run: cargo clippy --workspace --features download -- -D warnings
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run tests (no features)
+        run: cargo test --workspace
+      - name: Run tests (download feature)
+        run: cargo test --workspace --features download
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build (no features)
+        run: cargo build --workspace --release
+      - name: Build (download feature)
+        run: cargo build --workspace --release --features download


### PR DESCRIPTION
## Summary

- Add GitHub Actions CI workflow that runs on push to main and PRs
- Format check with `cargo fmt`
- Clippy lints (with and without download feature)
- Unit tests (with and without download feature)
- Release build verification

## Test plan

- [ ] Verify CI workflow runs on this PR
- [ ] Verify all checks pass (fmt, clippy, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)