### PR TITLE
feat: add ZIP archive support for SRTM tile downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "as-slice"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +322,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -636,6 +656,7 @@ dependencies = [
  "reqwest",
  "tempfile",
  "thiserror 1.0.69",
+ "zip",
 ]
 
 [[package]]
@@ -2534,4 +2555,33 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.17",
+ "zopfli",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
 ]

--- a/htg/Cargo.toml
+++ b/htg/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 
 [features]
 default = []
-download = ["dep:reqwest", "dep:flate2"]
+download = ["dep:reqwest", "dep:flate2", "dep:zip"]
 
 [dependencies]
 memmap2 = "0.9"
@@ -22,6 +22,7 @@ thiserror = "1.0"
 # Optional dependencies for download feature
 reqwest = { version = "0.12", features = ["blocking"], optional = true }
 flate2 = { version = "1.0", optional = true }
+zip = { version = "2.2", optional = true, default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/htg/src/lib.rs
+++ b/htg/src/lib.rs
@@ -46,14 +46,18 @@
 //! let service = SrtmServiceBuilder::new("/data/srtm")
 //!     .cache_size(100)
 //!     .auto_download(DownloadConfig::with_url_template(
-//!         "https://example.com/srtm/{filename}.hgt.gz",
-//!         true, // is gzipped
+//!         "https://example.com/srtm/{filename}.hgt.gz", // compression auto-detected
 //!     ))
 //!     .build()?;
 //!
 //! // Will download N35E138.hgt if not present locally
 //! let elevation = service.get_elevation(35.5, 138.5)?;
 //! ```
+//!
+//! Supported compression formats (auto-detected from URL extension):
+//! - `.hgt.gz` - Gzip compression
+//! - `.hgt.zip` - ZIP archive
+//! - `.hgt` - No compression
 //!
 //! ## Low-Level API
 //!


### PR DESCRIPTION
## Summary

Add support for downloading and extracting SRTM tiles from ZIP archives, in addition to existing gzip support. This enables auto-download from sources like ArduPilot and NASA Earthdata that distribute SRTM data as ZIP archives.

## Changes

### New Features
- Add `Compression` enum with `None`, `Gzip`, and `Zip` variants
- Auto-detect compression format from URL extension (`.gz`, `.zip`)
- Extract `.hgt` files from ZIP archives automatically

### API Changes
- `DownloadConfig::with_url_template(url)` - now takes single argument, auto-detects compression
- `DownloadConfig::with_url_template_and_compression(url, compression)` - explicit control
- Old two-argument API deprecated but still available

### Files Modified
- `htg/Cargo.toml` - Add `zip` crate dependency
- `htg/src/download.rs` - ZIP extraction logic and new API
- `htg/src/service.rs` - Update to use new API
- `htg/src/lib.rs` - Update documentation
- `htg-service/src/main.rs` - Update to use new API

## Usage Examples

```rust
// Auto-detect compression from URL (recommended)
let config = DownloadConfig::with_url_template(
    "https://example.com/srtm/{filename}.hgt.zip"
);

// Explicit compression setting
let config = DownloadConfig::with_url_template_and_compression(
    "https://example.com/srtm/{filename}.hgt.zip",
    Compression::Zip,
);
```

## Test plan
- [x] Unit tests for `Compression::from_url()` 
- [x] Unit tests for compression auto-detection
- [x] Unit tests for ZIP extraction with valid archive
- [x] Unit tests for ZIP extraction with missing .hgt file
- [x] All existing tests pass
- [x] Clippy clean
- [x] Builds successfully

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)