### PR TITLE
feat: Add CLI tool for offline elevation queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,6 +310,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "clap"
+version = "4.5.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +453,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +519,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -705,6 +841,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "htg-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "csv",
+ "geojson",
+ "htg",
+ "indicatif",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "htg-python"
 version = "0.2.0"
 dependencies = [
@@ -984,6 +1134,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,6 +1170,12 @@ dependencies = [
  "memchr",
  "serde",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -1206,10 +1375,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
@@ -1944,6 +2125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2311,6 +2498,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2339,6 +2532,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
@@ -2514,6 +2713,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2562,6 +2771,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["htg", "htg-service", "htg-python"]
+members = ["htg", "htg-service", "htg-python", "htg-cli"]
 resolver = "2"

--- a/htg-cli/Cargo.toml
+++ b/htg-cli/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "htg-cli"
+version = "0.1.0"
+edition = "2021"
+authors = ["Pedro Sánchez Martínez <pedrosanzmtz@users.noreply.github.com>"]
+description = "Command-line tool for SRTM elevation queries"
+license = "MIT"
+repository = "https://github.com/pedrosanzmtz/htg"
+
+[[bin]]
+name = "htg"
+path = "src/main.rs"
+
+[dependencies]
+htg = { path = "../htg", features = ["download", "geojson"] }
+
+# CLI framework
+clap = { version = "4", features = ["derive", "env"] }
+
+# File processing
+csv = "1.3"
+geojson = "0.24"
+
+# Progress bars
+indicatif = "0.17"
+
+# Serialization
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# Error handling
+anyhow = "1.0"

--- a/htg-cli/src/commands/batch.rs
+++ b/htg-cli/src/commands/batch.rs
@@ -1,0 +1,305 @@
+use anyhow::{bail, Context, Result};
+use htg::{download::DownloadConfig, SrtmServiceBuilder};
+use indicatif::{ProgressBar, ProgressStyle};
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Write};
+use std::path::PathBuf;
+
+#[allow(clippy::too_many_arguments)]
+pub fn run(
+    data_dir: Option<PathBuf>,
+    cache_size: u64,
+    auto_download: bool,
+    input: PathBuf,
+    output: Option<PathBuf>,
+    lat_col: String,
+    lon_col: String,
+    interpolate: bool,
+) -> Result<()> {
+    // Build the service
+    let mut builder = match data_dir {
+        Some(dir) => SrtmServiceBuilder::new(dir),
+        None => SrtmServiceBuilder::from_env().context(
+            "HTG_DATA_DIR environment variable not set. Use --data-dir or set HTG_DATA_DIR",
+        )?,
+    };
+
+    builder = builder.cache_size(cache_size);
+
+    if auto_download {
+        builder = builder.auto_download(DownloadConfig::ardupilot_srtm1());
+    }
+
+    let service = builder.build().context("Failed to create SRTM service")?;
+
+    // Detect file format
+    let extension = input
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+
+    match extension.as_str() {
+        "csv" => process_csv(&service, &input, output, &lat_col, &lon_col, interpolate),
+        "geojson" | "json" => process_geojson(&service, &input, output, interpolate),
+        _ => bail!(
+            "Unsupported file format: {}. Use .csv or .geojson",
+            extension
+        ),
+    }
+}
+
+fn process_csv(
+    service: &htg::SrtmService,
+    input: &PathBuf,
+    output: Option<PathBuf>,
+    lat_col: &str,
+    lon_col: &str,
+    interpolate: bool,
+) -> Result<()> {
+    let file = File::open(input).context("Failed to open input file")?;
+    let mut reader = csv::Reader::from_reader(BufReader::new(file));
+
+    // Find column indices
+    let headers = reader.headers()?.clone();
+    let lat_idx = headers
+        .iter()
+        .position(|h| h == lat_col)
+        .with_context(|| format!("Column '{}' not found in CSV", lat_col))?;
+    let lon_idx = headers
+        .iter()
+        .position(|h| h == lon_col)
+        .with_context(|| format!("Column '{}' not found in CSV", lon_col))?;
+
+    // Collect records for progress bar
+    let records: Vec<_> = reader.records().collect::<Result<_, _>>()?;
+    let total = records.len() as u64;
+
+    let pb = ProgressBar::new(total);
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template(
+                "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({eta})",
+            )?
+            .progress_chars("#>-"),
+    );
+
+    // Prepare output
+    let output_path = output.unwrap_or_else(|| {
+        let stem = input.file_stem().unwrap().to_string_lossy();
+        input.with_file_name(format!("{}_elevation.csv", stem))
+    });
+    let output_file = File::create(&output_path).context("Failed to create output file")?;
+    let mut writer = csv::Writer::from_writer(BufWriter::new(output_file));
+
+    // Write header
+    let mut new_headers: Vec<&str> = headers.iter().collect();
+    new_headers.push("elevation");
+    writer.write_record(&new_headers)?;
+
+    // Process records
+    for record in records {
+        let lat: f64 = record
+            .get(lat_idx)
+            .context("Missing latitude")?
+            .parse()
+            .context("Invalid latitude")?;
+        let lon: f64 = record
+            .get(lon_idx)
+            .context("Missing longitude")?
+            .parse()
+            .context("Invalid longitude")?;
+
+        let elevation = if interpolate {
+            service
+                .get_elevation_interpolated(lat, lon)
+                .ok()
+                .flatten()
+                .map(|e| format!("{:.2}", e))
+                .unwrap_or_else(|| "void".to_string())
+        } else {
+            service
+                .get_elevation(lat, lon)
+                .ok()
+                .map(|e| {
+                    if e == htg::VOID_VALUE {
+                        "void".to_string()
+                    } else {
+                        e.to_string()
+                    }
+                })
+                .unwrap_or_else(|| "error".to_string())
+        };
+
+        let mut new_record: Vec<&str> = record.iter().collect();
+        new_record.push(&elevation);
+        writer.write_record(&new_record)?;
+
+        pb.inc(1);
+    }
+
+    pb.finish_with_message("done");
+    writer.flush()?;
+
+    println!("Output written to: {}", output_path.display());
+    Ok(())
+}
+
+fn process_geojson(
+    service: &htg::SrtmService,
+    input: &PathBuf,
+    output: Option<PathBuf>,
+    interpolate: bool,
+) -> Result<()> {
+    let file = File::open(input).context("Failed to open input file")?;
+    let reader = BufReader::new(file);
+
+    let geojson: geojson::GeoJson =
+        serde_json::from_reader(reader).context("Failed to parse GeoJSON")?;
+
+    let result = match geojson {
+        geojson::GeoJson::Geometry(geometry) => {
+            let enriched = add_elevations_to_geometry(service, geometry, interpolate)?;
+            geojson::GeoJson::Geometry(enriched)
+        }
+        geojson::GeoJson::Feature(mut feature) => {
+            if let Some(geometry) = feature.geometry.take() {
+                feature.geometry =
+                    Some(add_elevations_to_geometry(service, geometry, interpolate)?);
+            }
+            geojson::GeoJson::Feature(feature)
+        }
+        geojson::GeoJson::FeatureCollection(mut fc) => {
+            let pb = ProgressBar::new(fc.features.len() as u64);
+            pb.set_style(
+                ProgressStyle::default_bar()
+                    .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({eta})")?
+                    .progress_chars("#>-"),
+            );
+
+            for feature in &mut fc.features {
+                if let Some(geometry) = feature.geometry.take() {
+                    feature.geometry =
+                        Some(add_elevations_to_geometry(service, geometry, interpolate)?);
+                }
+                pb.inc(1);
+            }
+            pb.finish_with_message("done");
+            geojson::GeoJson::FeatureCollection(fc)
+        }
+    };
+
+    // Write output
+    let output_path = output.unwrap_or_else(|| {
+        let stem = input.file_stem().unwrap().to_string_lossy();
+        input.with_file_name(format!("{}_elevation.geojson", stem))
+    });
+    let output_file = File::create(&output_path).context("Failed to create output file")?;
+    let mut writer = BufWriter::new(output_file);
+    serde_json::to_writer_pretty(&mut writer, &result)?;
+    writer.flush()?;
+
+    println!("Output written to: {}", output_path.display());
+    Ok(())
+}
+
+fn add_elevations_to_geometry(
+    service: &htg::SrtmService,
+    geometry: geojson::Geometry,
+    interpolate: bool,
+) -> Result<geojson::Geometry> {
+    use geojson::Value;
+
+    fn add_elevation_to_position(
+        service: &htg::SrtmService,
+        pos: &mut Vec<f64>,
+        interpolate: bool,
+    ) {
+        if pos.len() >= 2 {
+            let lon = pos[0];
+            let lat = pos[1];
+            let elevation = if interpolate {
+                service
+                    .get_elevation_interpolated(lat, lon)
+                    .ok()
+                    .flatten()
+                    .unwrap_or(0.0)
+            } else {
+                service.get_elevation(lat, lon).ok().unwrap_or(0) as f64
+            };
+            if pos.len() == 2 {
+                pos.push(elevation);
+            } else {
+                pos[2] = elevation;
+            }
+        }
+    }
+
+    fn process_positions(
+        service: &htg::SrtmService,
+        positions: &mut Vec<Vec<f64>>,
+        interpolate: bool,
+    ) {
+        for pos in positions {
+            add_elevation_to_position(service, pos, interpolate);
+        }
+    }
+
+    fn process_line_string(
+        service: &htg::SrtmService,
+        coords: &mut Vec<Vec<f64>>,
+        interpolate: bool,
+    ) {
+        process_positions(service, coords, interpolate);
+    }
+
+    fn process_polygon(
+        service: &htg::SrtmService,
+        rings: &mut Vec<Vec<Vec<f64>>>,
+        interpolate: bool,
+    ) {
+        for ring in rings {
+            process_positions(service, ring, interpolate);
+        }
+    }
+
+    let value = match geometry.value {
+        Value::Point(mut coords) => {
+            add_elevation_to_position(service, &mut coords, interpolate);
+            Value::Point(coords)
+        }
+        Value::MultiPoint(mut coords) => {
+            process_positions(service, &mut coords, interpolate);
+            Value::MultiPoint(coords)
+        }
+        Value::LineString(mut coords) => {
+            process_line_string(service, &mut coords, interpolate);
+            Value::LineString(coords)
+        }
+        Value::MultiLineString(mut lines) => {
+            for line in &mut lines {
+                process_line_string(service, line, interpolate);
+            }
+            Value::MultiLineString(lines)
+        }
+        Value::Polygon(mut rings) => {
+            process_polygon(service, &mut rings, interpolate);
+            Value::Polygon(rings)
+        }
+        Value::MultiPolygon(mut polys) => {
+            for poly in &mut polys {
+                process_polygon(service, poly, interpolate);
+            }
+            Value::MultiPolygon(polys)
+        }
+        Value::GeometryCollection(geometries) => {
+            let mut new_geometries = Vec::new();
+            for geom in geometries {
+                new_geometries.push(add_elevations_to_geometry(service, geom, interpolate)?);
+            }
+            Value::GeometryCollection(new_geometries)
+        }
+    };
+
+    Ok(geojson::Geometry::new(value))
+}

--- a/htg-cli/src/commands/info.rs
+++ b/htg-cli/src/commands/info.rs
@@ -1,0 +1,141 @@
+use anyhow::{bail, Context, Result};
+use htg::{filename::lat_lon_to_filename, SrtmResolution, SrtmTile, VOID_VALUE};
+use std::path::PathBuf;
+
+pub fn run(
+    data_dir: Option<PathBuf>,
+    tile: String,
+    lat: Option<f64>,
+    lon: Option<f64>,
+) -> Result<()> {
+    // Determine tile filename
+    let (filename, tile_path) = if let (Some(lat), Some(lon)) = (lat, lon) {
+        let filename = lat_lon_to_filename(lat, lon);
+        let path = get_tile_path(data_dir, &filename)?;
+        (filename, path)
+    } else if tile.ends_with(".hgt") {
+        // Full path provided
+        let path = PathBuf::from(&tile);
+        let filename = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(&tile)
+            .to_string();
+        (filename, path)
+    } else {
+        // Just tile name (e.g., "N35E138")
+        let filename = format!("{}.hgt", tile);
+        let path = get_tile_path(data_dir, &filename)?;
+        (filename, path)
+    };
+
+    // Check if file exists
+    if !tile_path.exists() {
+        bail!("Tile not found: {}", tile_path.display());
+    }
+
+    // Parse coordinates from filename first (needed for elevation sampling)
+    let (base_lat, base_lon) = htg::filename::filename_to_lat_lon(&filename).unwrap_or((0, 0));
+
+    // Load tile with coordinates
+    let tile = SrtmTile::from_file_with_coords(&tile_path, base_lat, base_lon)
+        .context("Failed to load tile")?;
+
+    // Get file metadata
+    let metadata = std::fs::metadata(&tile_path)?;
+    let file_size = metadata.len();
+
+    // Calculate min/max elevation by sampling through the grid
+    let samples = tile.samples();
+    let (mut min_elev, mut max_elev) = (i16::MAX, i16::MIN);
+    let mut void_count = 0u64;
+
+    // Iterate through all samples using lat/lon coordinates
+    // Row 0 = north edge, Row samples-1 = south edge
+    // Col 0 = west edge, Col samples-1 = east edge
+    for row in 0..samples {
+        for col in 0..samples {
+            // Calculate lat/lon for this sample
+            let lat = (base_lat as f64) + 1.0 - (row as f64 / (samples - 1) as f64);
+            let lon = (base_lon as f64) + (col as f64 / (samples - 1) as f64);
+
+            if let Ok(elev) = tile.get_elevation(lat, lon) {
+                if elev == VOID_VALUE {
+                    void_count += 1;
+                } else {
+                    min_elev = min_elev.min(elev);
+                    max_elev = max_elev.max(elev);
+                }
+            }
+        }
+    }
+
+    // Format resolution string
+    let resolution_str = match tile.resolution() {
+        SrtmResolution::Srtm1 => "SRTM1 (~30m)",
+        SrtmResolution::Srtm3 => "SRTM3 (~90m)",
+    };
+
+    // Display information
+    println!("Tile: {}", filename);
+    println!("Path: {}", tile_path.display());
+    println!();
+    println!(
+        "Resolution: {} ({}x{} samples)",
+        resolution_str, samples, samples
+    );
+    println!(
+        "Coverage: {}{}-{}{}, {}{}{}{}",
+        if base_lat >= 0 { "N" } else { "S" },
+        base_lat.abs(),
+        if base_lat >= 0 { "N" } else { "S" },
+        (base_lat + 1).abs(),
+        if base_lon >= 0 { "E" } else { "W" },
+        base_lon.abs(),
+        if base_lon >= 0 { "E" } else { "W" },
+        (base_lon + 1).abs()
+    );
+    println!("File size: {}", format_size(file_size));
+    println!();
+
+    if min_elev <= max_elev {
+        println!("Min elevation: {}m", min_elev);
+        println!("Max elevation: {}m", max_elev);
+    }
+
+    let total_samples = (samples * samples) as u64;
+    if void_count > 0 {
+        let void_pct = (void_count as f64 / total_samples as f64) * 100.0;
+        println!("Void samples: {} ({:.1}%)", void_count, void_pct);
+    }
+
+    Ok(())
+}
+
+fn get_tile_path(data_dir: Option<PathBuf>, filename: &str) -> Result<PathBuf> {
+    match data_dir {
+        Some(dir) => Ok(dir.join(filename)),
+        None => {
+            let dir = std::env::var("HTG_DATA_DIR").context(
+                "HTG_DATA_DIR environment variable not set. Use --data-dir or set HTG_DATA_DIR",
+            )?;
+            Ok(PathBuf::from(dir).join(filename))
+        }
+    }
+}
+
+fn format_size(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+
+    if bytes >= GB {
+        format!("{:.2} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.2} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.2} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{} bytes", bytes)
+    }
+}

--- a/htg-cli/src/commands/list.rs
+++ b/htg-cli/src/commands/list.rs
@@ -1,0 +1,133 @@
+use anyhow::{Context, Result};
+use htg::filename::filename_to_lat_lon;
+use std::fs;
+use std::path::PathBuf;
+
+pub fn run(data_dir: Option<PathBuf>) -> Result<()> {
+    let dir = match data_dir {
+        Some(dir) => dir,
+        None => {
+            let dir = std::env::var("HTG_DATA_DIR").context(
+                "HTG_DATA_DIR environment variable not set. Use --data-dir or set HTG_DATA_DIR",
+            )?;
+            PathBuf::from(dir)
+        }
+    };
+
+    if !dir.exists() {
+        anyhow::bail!("Data directory does not exist: {}", dir.display());
+    }
+
+    // Collect .hgt files
+    let mut tiles: Vec<_> = fs::read_dir(&dir)
+        .context("Failed to read data directory")?
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| {
+            entry
+                .path()
+                .extension()
+                .map(|e| e == "hgt")
+                .unwrap_or(false)
+        })
+        .collect();
+
+    if tiles.is_empty() {
+        println!("No .hgt files found in: {}", dir.display());
+        return Ok(());
+    }
+
+    // Sort by filename
+    tiles.sort_by_key(|e| e.file_name());
+
+    // Detect resolution from file size
+    const SRTM1_SIZE: u64 = 3601 * 3601 * 2;
+    const SRTM3_SIZE: u64 = 1201 * 1201 * 2;
+
+    let mut srtm1_count = 0;
+    let mut srtm3_count = 0;
+    let mut unknown_count = 0;
+    let mut total_size: u64 = 0;
+
+    println!("{:<12} {:>8} {:>20}", "TILE", "TYPE", "COVERAGE");
+    println!("{}", "-".repeat(44));
+
+    for entry in &tiles {
+        let filename = entry.file_name();
+        let filename_str = filename.to_string_lossy();
+        let path = entry.path();
+
+        let metadata = fs::metadata(&path).ok();
+        let size = metadata.as_ref().map(|m| m.len()).unwrap_or(0);
+        total_size += size;
+
+        let resolution = match size {
+            s if s == SRTM1_SIZE => {
+                srtm1_count += 1;
+                "SRTM1"
+            }
+            s if s == SRTM3_SIZE => {
+                srtm3_count += 1;
+                "SRTM3"
+            }
+            _ => {
+                unknown_count += 1;
+                "???"
+            }
+        };
+
+        // Parse coverage from filename
+        let coverage = if let Some((lat, lon)) = filename_to_lat_lon(&filename_str) {
+            let lat_prefix = if lat >= 0 { "N" } else { "S" };
+            let lon_prefix = if lon >= 0 { "E" } else { "W" };
+            format!(
+                "{}{:02} to {}{:02}, {}{:03} to {}{:03}",
+                lat_prefix,
+                lat.abs(),
+                lat_prefix,
+                (lat + 1).abs(),
+                lon_prefix,
+                lon.abs(),
+                lon_prefix,
+                (lon + 1).abs()
+            )
+        } else {
+            "Unknown".to_string()
+        };
+
+        println!("{:<12} {:>8} {:>20}", filename_str, resolution, coverage);
+    }
+
+    // Summary
+    println!();
+    println!("Summary:");
+    println!("  Total tiles: {}", tiles.len());
+    if srtm1_count > 0 {
+        println!("  SRTM1 (30m): {}", srtm1_count);
+    }
+    if srtm3_count > 0 {
+        println!("  SRTM3 (90m): {}", srtm3_count);
+    }
+    if unknown_count > 0 {
+        println!("  Unknown: {}", unknown_count);
+    }
+    println!("  Total size: {}", format_size(total_size));
+    println!("  Data directory: {}", dir.display());
+
+    Ok(())
+}
+
+fn format_size(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+
+    if bytes >= GB {
+        format!("{:.2} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.2} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.2} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{} bytes", bytes)
+    }
+}

--- a/htg-cli/src/commands/mod.rs
+++ b/htg-cli/src/commands/mod.rs
@@ -1,0 +1,4 @@
+pub mod batch;
+pub mod info;
+pub mod list;
+pub mod query;

--- a/htg-cli/src/commands/query.rs
+++ b/htg-cli/src/commands/query.rs
@@ -1,0 +1,80 @@
+use anyhow::{Context, Result};
+use htg::{download::DownloadConfig, SrtmServiceBuilder, VOID_VALUE};
+use serde::Serialize;
+use std::path::PathBuf;
+
+#[derive(Serialize)]
+struct ElevationResponse {
+    lat: f64,
+    lon: f64,
+    elevation: Option<f64>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    interpolated: bool,
+}
+
+pub fn run(
+    data_dir: Option<PathBuf>,
+    cache_size: u64,
+    auto_download: bool,
+    lat: f64,
+    lon: f64,
+    interpolate: bool,
+    json: bool,
+) -> Result<()> {
+    // Build the service
+    let mut builder = match data_dir {
+        Some(dir) => SrtmServiceBuilder::new(dir),
+        None => SrtmServiceBuilder::from_env().context(
+            "HTG_DATA_DIR environment variable not set. Use --data-dir or set HTG_DATA_DIR",
+        )?,
+    };
+
+    builder = builder.cache_size(cache_size);
+
+    if auto_download {
+        builder = builder.auto_download(DownloadConfig::ardupilot_srtm1());
+    }
+
+    let service = builder.build().context("Failed to create SRTM service")?;
+
+    // Query elevation
+    let (elevation, is_void) = if interpolate {
+        match service
+            .get_elevation_interpolated(lat, lon)
+            .context("Failed to get elevation")?
+        {
+            Some(elev) => (Some(elev), false),
+            None => (None, true),
+        }
+    } else {
+        let elev = service
+            .get_elevation(lat, lon)
+            .context("Failed to get elevation")?;
+        if elev == VOID_VALUE {
+            (None, true)
+        } else {
+            (Some(elev as f64), false)
+        }
+    };
+
+    // Output result
+    if json {
+        let response = ElevationResponse {
+            lat,
+            lon,
+            elevation,
+            interpolated: interpolate,
+        };
+        println!("{}", serde_json::to_string(&response)?);
+    } else if is_void {
+        println!("void");
+    } else if let Some(elev) = elevation {
+        if interpolate {
+            println!("{:.2}", elev);
+        } else {
+            println!("{}", elev as i16);
+        }
+    }
+
+    Ok(())
+}

--- a/htg-cli/src/main.rs
+++ b/htg-cli/src/main.rs
@@ -1,0 +1,132 @@
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use std::path::PathBuf;
+
+mod commands;
+
+/// SRTM elevation data CLI tool
+#[derive(Parser)]
+#[command(name = "htg")]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    /// Directory containing .hgt files
+    #[arg(short, long, env = "HTG_DATA_DIR", global = true)]
+    data_dir: Option<PathBuf>,
+
+    /// Maximum tiles in cache
+    #[arg(
+        short,
+        long,
+        env = "HTG_CACHE_SIZE",
+        default_value = "100",
+        global = true
+    )]
+    cache_size: u64,
+
+    /// Enable automatic tile download
+    #[arg(short, long, global = true)]
+    auto_download: bool,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Query elevation for a single coordinate
+    Query {
+        /// Latitude in decimal degrees
+        #[arg(long)]
+        lat: f64,
+
+        /// Longitude in decimal degrees
+        #[arg(long)]
+        lon: f64,
+
+        /// Use bilinear interpolation for sub-pixel accuracy
+        #[arg(short, long)]
+        interpolate: bool,
+
+        /// Output result as JSON
+        #[arg(short, long)]
+        json: bool,
+    },
+
+    /// Process elevation for multiple coordinates from a file
+    Batch {
+        /// Input file (CSV or GeoJSON)
+        input: PathBuf,
+
+        /// Output file (same format as input if not specified)
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+
+        /// Column name for latitude (CSV only)
+        #[arg(long, default_value = "lat")]
+        lat_col: String,
+
+        /// Column name for longitude (CSV only)
+        #[arg(long, default_value = "lon")]
+        lon_col: String,
+
+        /// Use bilinear interpolation
+        #[arg(short, long)]
+        interpolate: bool,
+    },
+
+    /// Display information about an SRTM tile
+    Info {
+        /// Path to .hgt file, or tile name (e.g., N35E138)
+        tile: String,
+
+        /// Specify tile by latitude instead of filename
+        #[arg(long, conflicts_with = "tile")]
+        lat: Option<f64>,
+
+        /// Specify tile by longitude instead of filename
+        #[arg(long, conflicts_with = "tile")]
+        lon: Option<f64>,
+    },
+
+    /// List available SRTM tiles
+    List,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Query {
+            lat,
+            lon,
+            interpolate,
+            json,
+        } => commands::query::run(
+            cli.data_dir,
+            cli.cache_size,
+            cli.auto_download,
+            lat,
+            lon,
+            interpolate,
+            json,
+        ),
+        Commands::Batch {
+            input,
+            output,
+            lat_col,
+            lon_col,
+            interpolate,
+        } => commands::batch::run(
+            cli.data_dir,
+            cli.cache_size,
+            cli.auto_download,
+            input,
+            output,
+            lat_col,
+            lon_col,
+            interpolate,
+        ),
+        Commands::Info { tile, lat, lon } => commands::info::run(cli.data_dir, tile, lat, lon),
+        Commands::List => commands::list::run(cli.data_dir),
+    }
+}


### PR DESCRIPTION
## Summary

- Add `htg-cli` binary crate for offline elevation queries from the command line
- Implements all commands from issue #25: query, batch, info, list
- Supports CSV and GeoJSON batch processing with progress bars
- Includes auto-download support via `--auto-download` flag

## Commands

| Command | Description |
|---------|-------------|
| `htg query --lat <LAT> --lon <LON>` | Single point elevation lookup |
| `htg batch <INPUT>` | Process CSV or GeoJSON files |
| `htg info <TILE>` | Display tile information |
| `htg list` | List available tiles |

## Test plan

- [x] `cargo build -p htg-cli` compiles successfully
- [x] `cargo clippy -p htg-cli -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `htg --help` shows all commands
- [ ] Test query command with real .hgt file
- [ ] Test batch command with CSV input
- [ ] Test batch command with GeoJSON input

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)