### PR TITLE
chore: Add CODEOWNERS for required reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @pedrosanzmtz


### PR DESCRIPTION
## Summary

Add CODEOWNERS file to require @pedrosanzmtz approval on all PRs.

## Changes

- `.github/CODEOWNERS` - assigns @pedrosanzmtz as code owner for all files

🤖 Generated with [Claude Code](https://claude.com/claude-code)