### PR TITLE
fix: bump htg-python version to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "htg"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "flate2",
  "geojson",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "htg-python"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "htg",
  "pyo3",

--- a/htg-python/Cargo.toml
+++ b/htg-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htg-python"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Pedro Sánchez Martínez <pedrosanzmtz@users.noreply.github.com>"]
 description = "Python bindings for htg SRTM elevation library"


### PR DESCRIPTION
## Summary
- Bumps htg-python version from 0.2.0 to 0.2.1 to match the htg library version

## Problem
The release workflow failed because:
1. htg/Cargo.toml was bumped to 0.2.1
2. htg-python/Cargo.toml was still at 0.2.0
3. PyPI rejected the upload because `srtm-0.2.0` wheels already exist

## Fix
Align the Python package version with the Rust library version.

## Test plan
- [ ] Merge this PR
- [ ] Release workflow should succeed and:
  - Publish `srtm` 0.2.1 to PyPI
  - Update Docker Hub description

🤖 Generated with [Claude Code](https://claude.com/claude-code)