### PR TITLE
feat!: safe Option API, batch queries, .hgt.zip support (v0.3.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "htg"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "flate2",
  "geojson",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "htg-python"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "htg",
  "pyo3",

--- a/htg-cli/src/commands/batch.rs
+++ b/htg-cli/src/commands/batch.rs
@@ -121,14 +121,9 @@ fn process_csv(
             service
                 .get_elevation(lat, lon)
                 .ok()
-                .map(|e| {
-                    if e == htg::VOID_VALUE {
-                        "void".to_string()
-                    } else {
-                        e.to_string()
-                    }
-                })
-                .unwrap_or_else(|| "error".to_string())
+                .flatten()
+                .map(|e| e.to_string())
+                .unwrap_or_else(|| "void".to_string())
         };
 
         let mut new_record: Vec<&str> = record.iter().collect();
@@ -225,7 +220,7 @@ fn add_elevations_to_geometry(
                     .flatten()
                     .unwrap_or(0.0)
             } else {
-                service.get_elevation(lat, lon).ok().unwrap_or(0) as f64
+                service.get_elevation(lat, lon).ok().flatten().unwrap_or(0) as f64
             };
             if pos.len() == 2 {
                 pos.push(elevation);

--- a/htg-cli/src/commands/query.rs
+++ b/htg-cli/src/commands/query.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use htg::{download::DownloadConfig, SrtmServiceBuilder, VOID_VALUE};
+use htg::{download::DownloadConfig, SrtmServiceBuilder};
 use serde::Serialize;
 use std::path::PathBuf;
 
@@ -47,13 +47,12 @@ pub fn run(
             None => (None, true),
         }
     } else {
-        let elev = service
+        match service
             .get_elevation(lat, lon)
-            .context("Failed to get elevation")?;
-        if elev == VOID_VALUE {
-            (None, true)
-        } else {
-            (Some(elev as f64), false)
+            .context("Failed to get elevation")?
+        {
+            Some(elev) => (Some(elev as f64), false),
+            None => (None, true),
         }
     };
 

--- a/htg-python/Cargo.toml
+++ b/htg-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htg-python"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["Pedro Sánchez Martínez <pedrosanzmtz@users.noreply.github.com>"]
 description = "Python bindings for htg SRTM elevation library"

--- a/htg-python/pyproject.toml
+++ b/htg-python/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Rust",
     "Topic :: Scientific/Engineering :: GIS",
 ]

--- a/htg-python/python/srtm/__init__.pyi
+++ b/htg-python/python/srtm/__init__.pyi
@@ -1,6 +1,6 @@
 """Type stubs for srtm - High-performance SRTM elevation library."""
 
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 __version__: str
 VOID_VALUE: int
@@ -42,7 +42,7 @@ class SrtmService:
         """
         ...
 
-    def get_elevation(self, lat: float, lon: float) -> int:
+    def get_elevation(self, lat: float, lon: float) -> Optional[int]:
         """Get elevation at the specified coordinates using nearest-neighbor lookup.
 
         Args:
@@ -50,10 +50,24 @@ class SrtmService:
             lon: Longitude in decimal degrees (-180 to 180).
 
         Returns:
-            Elevation in meters.
+            Elevation in meters, or None if no data available.
 
         Raises:
-            ValueError: If coordinates are out of bounds or tile is not found.
+            ValueError: If coordinates are out of bounds.
+        """
+        ...
+
+    def get_elevations_batch(
+        self, coords: List[Tuple[float, float]], default: int = 0
+    ) -> List[int]:
+        """Get elevations for a batch of coordinates.
+
+        Args:
+            coords: List of (lat, lon) tuples.
+            default: Default value for void/missing data.
+
+        Returns:
+            List of elevation values in meters.
         """
         ...
 

--- a/htg-python/src/lib.rs
+++ b/htg-python/src/lib.rs
@@ -85,14 +85,27 @@ impl SrtmService {
     ///     lon: Longitude in decimal degrees (-180 to 180).
     ///
     /// Returns:
-    ///     Elevation in meters.
+    ///     Elevation in meters, or None if no data available (void, missing tile).
     ///
     /// Raises:
-    ///     ValueError: If coordinates are out of bounds or tile is not found.
-    fn get_elevation(&self, lat: f64, lon: f64) -> PyResult<i16> {
+    ///     ValueError: If coordinates are out of bounds.
+    fn get_elevation(&self, lat: f64, lon: f64) -> PyResult<Option<i16>> {
         self.inner
             .get_elevation(lat, lon)
             .map_err(|e| PyValueError::new_err(e.to_string()))
+    }
+
+    /// Get elevations for a batch of coordinates.
+    ///
+    /// Args:
+    ///     coords: List of (lat, lon) tuples.
+    ///     default: Default value for void/missing data (default: 0).
+    ///
+    /// Returns:
+    ///     List of elevation values in meters.
+    #[pyo3(signature = (coords, default=0))]
+    fn get_elevations_batch(&self, coords: Vec<(f64, f64)>, default: i16) -> Vec<i16> {
+        self.inner.get_elevations_batch(&coords, default)
     }
 
     /// Get elevation at the specified coordinates using bilinear interpolation.

--- a/htg-service/tests/api_tests.rs
+++ b/htg-service/tests/api_tests.rs
@@ -303,14 +303,16 @@ async fn test_geojson_missing_tile() {
     let temp_dir = TempDir::new().unwrap();
     let server = create_test_server(&temp_dir).await;
 
-    // No tile exists for these coordinates
+    // No tile exists for these coordinates — elevation defaults to 0
     let geometry = Geometry::new(GeoJsonValue::Point(vec![50.0, 50.0]));
 
     let response = server.post("/elevation").json(&geometry).await;
 
-    response.assert_status(axum::http::StatusCode::BAD_REQUEST);
+    response.assert_status_ok();
     let json: Value = response.json();
-    assert!(json["error"].as_str().is_some());
+    assert_eq!(json["type"], "Point");
+    let coords = json["coordinates"].as_array().unwrap();
+    assert_eq!(coords[2].as_f64().unwrap(), 0.0);
 }
 
 #[tokio::test]

--- a/htg/Cargo.toml
+++ b/htg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htg"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["Pedro Sánchez Martínez <pedrosanzmtz@users.noreply.github.com>"]
 description = "High-performance SRTM elevation data library"
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [features]
 default = []
-download = ["dep:reqwest", "dep:flate2", "dep:zip"]
+download = ["dep:reqwest", "dep:flate2"]
 geojson = ["dep:geojson"]
 
 [dependencies]
@@ -23,7 +23,7 @@ thiserror = "1.0"
 # Optional dependencies for download feature
 reqwest = { version = "0.12", features = ["blocking"], optional = true }
 flate2 = { version = "1.0", optional = true }
-zip = { version = "2.2", optional = true, default-features = false, features = ["deflate"] }
+zip = { version = "2.2", default-features = false, features = ["deflate"] }
 
 # Optional dependency for geojson feature
 geojson = { version = "0.24", optional = true }

--- a/htg/examples/basic.rs
+++ b/htg/examples/basic.rs
@@ -27,11 +27,11 @@ fn main() -> Result<(), SrtmError> {
 
     for (name, lat, lon) in &locations {
         match service.get_elevation(*lat, *lon) {
-            Ok(elevation) => {
+            Ok(Some(elevation)) => {
                 println!("{}: {}m", name, elevation);
             }
-            Err(SrtmError::FileNotFound { .. }) => {
-                println!("{}: tile not available locally", name);
+            Ok(None) => {
+                println!("{}: no data available", name);
             }
             Err(e) => {
                 println!("{}: error - {}", name, e);

--- a/htg/examples/interpolation.rs
+++ b/htg/examples/interpolation.rs
@@ -22,8 +22,12 @@ fn main() -> Result<(), SrtmError> {
 
     // Nearest-neighbor lookup
     match service.get_elevation(lat, lon) {
-        Ok(elevation) => {
+        Ok(Some(elevation)) => {
             println!("Nearest-neighbor: {}m", elevation);
+        }
+        Ok(None) => {
+            println!("No data available");
+            return Ok(());
         }
         Err(e) => {
             println!("Error: {}", e);

--- a/htg/src/geojson.rs
+++ b/htg/src/geojson.rs
@@ -163,9 +163,9 @@ pub fn add_elevation_to_coord(service: &SrtmService, coord: &[f64]) -> Result<Ve
     let lon = coord[0];
     let lat = coord[1];
 
-    let elevation = service.get_elevation(lat, lon)?;
+    let elevation = service.get_elevation(lat, lon)?.unwrap_or(0) as f64;
 
-    Ok(vec![lon, lat, elevation as f64])
+    Ok(vec![lon, lat, elevation])
 }
 
 /// Add elevations to a list of GeoJSON coordinates.


### PR DESCRIPTION
## Summary

- **BREAKING**: `SrtmService::get_elevation()` returns `Result<Option<i16>>` — `Ok(None)` for void data, missing tiles, or unavailable tiles instead of `Err`
- **New**: `get_elevations_batch(coords, default)` for efficient multi-coordinate queries (eliminates N FFI crossings from Python)
- **New**: Transparent `.hgt.zip` extraction — place `.hgt.zip` files in data dir, they're extracted on first access
- **New**: Python 3.13 classifier and `get_elevations_batch()` Python binding
- Version bump to **0.3.0** (htg + htg-python)

### Files changed (16)

| Area | Files | Change |
|------|-------|--------|
| Core library | `htg/src/service.rs`, `htg/Cargo.toml` | Option API, batch, zip extract, 5 new tests |
| GeoJSON | `htg/src/geojson.rs` | Handle Option with `.unwrap_or(0)` |
| HTTP service | `htg-service/src/handlers.rs`, `tests/api_tests.rs` | 404 for no-data, updated test expectations |
| CLI | `htg-cli/src/commands/query.rs`, `batch.rs` | Remove VOID_VALUE checks, use Option |
| Python | `htg-python/src/lib.rs`, `__init__.pyi`, `pyproject.toml` | Option return, batch binding, 3.13 |
| Examples | `htg/examples/basic.rs`, `interpolation.rs` | Updated match arms |
| Docs | `CLAUDE.md`, `README.md` | Updated for v0.3.0 API, added Python section |

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo clippy --workspace --features download -- -D warnings` passes
- [x] `cargo test --workspace` — 75 tests pass
- [x] `cargo test -p htg --features download` — 51 tests pass
- [x] `cargo build --release -p htg -p htg-service -p htg-cli` passes
- [ ] CI pipeline passes

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)