### PR TITLE
feat: Python 3.12+3.13 wheels, ARM64 support, README update (v0.3.1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,40 +68,62 @@ jobs:
 
   # Python library → PyPI
   build-python-wheels:
-    name: Build Python wheels (${{ matrix.os }})
+    name: Build Python wheels (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     needs: [check-version, test]
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: macos-13
+            target: x86_64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install maturin
-        run: pip install maturin
-
       - name: Build wheels
-        working-directory: htg-python
-        run: maturin build --release --out ../dist
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --interpreter 3.12 3.13
+          working-directory: htg-python
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}
-          path: dist/*.whl
+          name: wheels-${{ matrix.target }}
+          path: htg-python/dist/*.whl
+
+  build-python-sdist:
+    name: Build Python sdist
+    runs-on: ubuntu-latest
+    needs: [check-version, test]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist
+          working-directory: htg-python
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: htg-python/dist/*.tar.gz
 
   publish-python:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: [check-version, build-python-wheels]
+    needs: [check-version, build-python-wheels, build-python-sdist]
     permissions:
       id-token: write
     steps:
@@ -111,6 +133,12 @@ jobs:
           pattern: wheels-*
           path: dist
           merge-multiple: true
+
+      - name: Download sdist
+        uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "htg"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "flate2",
  "geojson",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "htg-python"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "htg",
  "pyo3",

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Existing elevation services (e.g., Python/Flask) consume excessive memory (7GB+)
 - **LRU Caching**: Configurable cache size to bound memory usage
 - **Safe API**: Service-level methods return `Option` for void/missing data
 - **Batch Queries**: `get_elevations_batch()` for efficient multi-coordinate lookups
-- **Python Bindings**: Native Python package via PyO3 (Python 3.8-3.13)
+- **Python Bindings**: Native Python package via PyO3 (Python 3.12+)
 - **Docker Ready**: Easy deployment with Docker/Docker Compose
 - **OpenAPI Docs**: Interactive Swagger UI at `/docs`
 
@@ -375,7 +375,7 @@ htg --data-dir /path/to/srtm --cache-size 50 --auto-download query --lat 35.5 --
 
 ## Python Bindings
 
-The `srtm` Python package provides native bindings via PyO3. Supports Python 3.8-3.13.
+The `srtm` Python package provides native bindings via PyO3. Supports Python 3.12+.
 
 ### Installation
 

--- a/htg-python/Cargo.toml
+++ b/htg-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htg-python"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Pedro Sánchez Martínez <pedrosanzmtz@users.noreply.github.com>"]
 description = "Python bindings for htg SRTM elevation library"

--- a/htg-python/pyproject.toml
+++ b/htg-python/pyproject.toml
@@ -9,17 +9,13 @@ description = "High-performance SRTM elevation data library"
 readme = "README.md"
 license = { text = "MIT" }
 authors = [{ name = "Pedro Sánchez Martínez", email = "pedrosanzmtz@users.noreply.github.com" }]
-requires-python = ">=3.8"
+requires-python = ">=3.12"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Rust",

--- a/htg/Cargo.toml
+++ b/htg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htg"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Pedro Sánchez Martínez <pedrosanzmtz@users.noreply.github.com>"]
 description = "High-performance SRTM elevation data library"


### PR DESCRIPTION
## Summary

- **Release workflow**: Switch from raw `maturin build` to `PyO3/maturin-action@v1` with a 5-target matrix (linux x86_64, linux aarch64, macos ARM64, macos x86_64, windows x86_64), building wheels for both Python 3.12 and 3.13 — producing 10 wheels + 1 sdist (up from 3 wheels)
- **Python README**: Fix PyPI badge URL (`htg` → `srtm`), update Quick Start with `None` return handling (v0.3.0 Option API), add `get_elevations_batch()` and `.hgt.zip` examples
- **Python metadata**: Narrow `requires-python` to `>=3.12`, remove 3.8–3.11 classifiers
- **Version bump**: 0.3.0 → 0.3.1 to trigger the release pipeline on merge

Closes #63

## Test plan

- [x] YAML syntax validated (`yaml.safe_load`)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace` passes
- [x] `cargo test --workspace` passes (77 tests)
- [ ] CI passes on PR
- [ ] After merge, release workflow triggers and publishes 10 wheels + sdist to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)