### PR TITLE
fix: use macos-latest for x86_64 cross-compile, bump to v0.3.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
           - os: macos-latest
             target: aarch64-apple-darwin
-          - os: macos-13
+          - os: macos-latest
             target: x86_64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "htg"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "flate2",
  "geojson",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "htg-python"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "htg",
  "pyo3",

--- a/htg-python/Cargo.toml
+++ b/htg-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htg-python"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = ["Pedro Sánchez Martínez <pedrosanzmtz@users.noreply.github.com>"]
 description = "Python bindings for htg SRTM elevation library"

--- a/htg/Cargo.toml
+++ b/htg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htg"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = ["Pedro Sánchez Martínez <pedrosanzmtz@users.noreply.github.com>"]
 description = "High-performance SRTM elevation data library"


### PR DESCRIPTION
## Summary

- **Fix**: The `macos-13` runner was cancelled/unavailable in the v0.3.1 release run, causing the entire PyPI publish and GitHub release to be skipped. Switch `x86_64-apple-darwin` target to use `macos-latest` (ARM64 runner) and cross-compile via `maturin-action` instead.
- **Version bump**: 0.3.1 → 0.3.2 to re-trigger the release pipeline on merge (v0.3.1 tag already exists from the partial run)

Closes #63

## Root cause

`macos-13` runners are being deprecated by GitHub Actions. The job was cancelled before a runner was assigned (started_at == completed_at, no runner_name). All other 4 targets succeeded.

## Test plan

- [x] YAML syntax validated
- [x] `cargo test --workspace` passes
- [ ] CI passes on PR
- [ ] After merge, release workflow builds all 10 wheels and publishes to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)