### PR TITLE
feat: add preload API with bounding box filtering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Building a high-performance, memory-efficient microservice to return elevation d
 ## Current Status
 
 **Phase:** All core phases complete (1-5)
-**Latest Features:** Safe Option-based elevation API (v0.3.0), batch query API, .hgt.zip support, bilinear interpolation, GeoJSON batch queries, auto-download, ArduPilot source support
+**Latest Features:** Safe Option-based elevation API (v0.3.0), batch query API, .hgt.zip support, bilinear interpolation, GeoJSON batch queries, auto-download, ArduPilot source support, preload API with bounding box filtering
 
 ### Open Issues
 - #6: Publish htg library to crates.io
@@ -46,6 +46,7 @@ Building a high-performance, memory-efficient microservice to return elevation d
 9. **Safe Option API:** Service-level methods return `Option` for void/missing data (v0.3.0)
 10. **Batch Query API:** `get_elevations_batch()` for efficient multi-coordinate queries
 11. **ZIP Support:** Transparent extraction of local `.hgt.zip` files
+12. **Preload API:** `preload()` method to warm the LRU cache at startup with optional bounding box filtering
 
 ### Reference Implementation
 The Go library `asmyasnikov/srtm` was used as algorithm reference:
@@ -214,6 +215,7 @@ curl "http://localhost:8080/stats"
 | `HTG_DOWNLOAD_SOURCE` | Named source: "ardupilot", "ardupilot-srtm1", "ardupilot-srtm3" | None |
 | `HTG_DOWNLOAD_URL` | URL template for auto-download (use `{filename}`, `{continent}` placeholders) | None |
 | `HTG_DOWNLOAD_GZIP` | Whether downloads are gzipped | false |
+| `HTG_PRELOAD` | Preload tiles at startup: "true"/"all"/"1" for all, or bounding boxes (e.g., "24.0,-125.0,50.0,-66.0") | None |
 | `RUST_LOG` | Log level (e.g., "info", "debug", "htg_service=debug") | "info" |
 
 ## Development Phases

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "htg"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "flate2",
  "geojson",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "htg-python"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "htg",
  "pyo3",

--- a/htg-python/Cargo.toml
+++ b/htg-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htg-python"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 authors = ["Pedro Sánchez Martínez <pedrosanzmtz@users.noreply.github.com>"]
 description = "Python bindings for htg SRTM elevation library"

--- a/htg-python/README.md
+++ b/htg-python/README.md
@@ -79,6 +79,29 @@ elevations = service.get_elevations_batch(coords, default=0)
 print(elevations)  # [3776, 8752, 3148]
 ```
 
+## Preloading Tiles
+
+Warm the cache at startup to avoid cold-start latency (useful when tiles are on NFS):
+
+```python
+import srtm
+
+service = srtm.SrtmService("/path/to/srtm", cache_size=100)
+
+# Preload all tiles
+stats = service.preload()
+print(f"Loaded {stats.tiles_loaded} tiles in {stats.elapsed_ms}ms")
+
+# Preload only CONUS + Hawaii tiles
+stats = service.preload(bounds=[
+    (24.0, -125.0, 50.0, -66.0),   # CONUS
+    (19.0, -161.0, 22.0, -154.0),  # Hawaii
+])
+
+# Non-blocking preload (runs in background thread)
+service.preload(blocking=False)
+```
+
 ## Utility Functions
 
 ```python

--- a/htg-python/python/srtm/__init__.py
+++ b/htg-python/python/srtm/__init__.py
@@ -2,6 +2,7 @@
 # This file just ensures the package is recognized and provides type hints
 from srtm.srtm import (  # type: ignore[import]
     CacheStats as CacheStats,
+    PreloadStats as PreloadStats,
     SrtmService as SrtmService,
     VOID_VALUE as VOID_VALUE,
     __version__ as __version__,
@@ -12,6 +13,7 @@ from srtm.srtm import (  # type: ignore[import]
 __all__ = [
     "SrtmService",
     "CacheStats",
+    "PreloadStats",
     "lat_lon_to_filename",
     "filename_to_lat_lon",
     "__version__",

--- a/htg-python/python/srtm/__init__.pyi
+++ b/htg-python/python/srtm/__init__.pyi
@@ -22,6 +22,24 @@ class CacheStats:
         """Cache hit rate (0.0 to 1.0)."""
         ...
 
+class PreloadStats:
+    """Statistics from a preload operation."""
+
+    tiles_loaded: int
+    """Number of tiles successfully loaded into cache."""
+
+    tiles_already_cached: int
+    """Number of tiles that were already in cache."""
+
+    tiles_failed: int
+    """Number of tiles that failed to load."""
+
+    tiles_matched: int
+    """Number of tiles that matched the bounding box filter."""
+
+    elapsed_ms: int
+    """Total elapsed time in milliseconds."""
+
 class SrtmService:
     """SRTM elevation service with LRU caching.
 
@@ -113,6 +131,27 @@ class SrtmService:
 
         Raises:
             ValueError: If coordinates are out of bounds or tile is not found.
+        """
+        ...
+
+    def preload(
+        self,
+        bounds: Optional[List[Tuple[float, float, float, float]]] = None,
+        blocking: bool = True,
+    ) -> Optional[PreloadStats]:
+        """Preload tiles into the LRU cache.
+
+        Scans the data directory for .hgt and .hgt.zip files and loads them
+        into cache. Useful for warming the cache at startup.
+
+        Args:
+            bounds: Optional list of bounding boxes as (min_lat, min_lon, max_lat, max_lon) tuples.
+                If provided, only tiles overlapping at least one box are loaded.
+            blocking: If True (default), blocks until preload completes and returns stats.
+                If False, runs preload in a background thread and returns None immediately.
+
+        Returns:
+            PreloadStats if blocking=True, None if blocking=False.
         """
         ...
 

--- a/htg/Cargo.toml
+++ b/htg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htg"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 authors = ["Pedro Sánchez Martínez <pedrosanzmtz@users.noreply.github.com>"]
 description = "High-performance SRTM elevation data library"

--- a/htg/README.md
+++ b/htg/README.md
@@ -14,6 +14,7 @@ High-performance, memory-efficient Rust library for querying elevation data from
 - **Auto-Download**: Optional automatic tile download (enable `download` feature)
 - **Bilinear Interpolation**: Sub-pixel accuracy for smooth elevation profiles
 - **Floor Rounding Mode**: srtm.py-compatible grid cell selection
+- **Preload API**: Warm the cache at startup with optional bounding box filtering
 
 ## Installation
 
@@ -44,6 +45,15 @@ if let Some(elevation) = service.get_elevation_interpolated(35.6762, 139.6503)? 
 
 // Floor-based rounding (srtm.py compatible)
 let elevation = service.get_elevation_floor(35.6762, 139.6503)?;
+
+// Preload tiles into cache (avoids cold-start latency on NFS)
+let stats = service.preload(None); // all tiles
+println!("Loaded {} tiles in {}ms", stats.tiles_loaded, stats.elapsed_ms);
+
+// Preload with bounding box filter
+use htg::BoundingBox;
+let conus = BoundingBox::new(24.0, -125.0, 50.0, -66.0);
+let stats = service.preload(Some(&[conus]));
 ```
 
 ## Auto-Download

--- a/htg/src/lib.rs
+++ b/htg/src/lib.rs
@@ -104,5 +104,5 @@ pub mod tile;
 
 // Re-export main types at crate root for convenience
 pub use error::{Result, SrtmError};
-pub use service::{CacheStats, SrtmService, SrtmServiceBuilder};
+pub use service::{BoundingBox, CacheStats, PreloadStats, SrtmService, SrtmServiceBuilder};
 pub use tile::{SrtmResolution, SrtmTile, VOID_VALUE};


### PR DESCRIPTION
## Summary

- Add `preload()` method to `SrtmService` that warms the LRU cache at startup, addressing cold-start latency when tiles reside on NFS (~63s first query vs 7-13ms warm)
- Support optional bounding box filtering so users can preload only the tiles they need (e.g., CONUS + Hawaii)
- Add `HTG_PRELOAD` env var for service startup preload (`true`/`all`/`1` for all tiles, or semicolon-separated bounding boxes)
- Add Python bindings with `blocking=True/False` modes (non-blocking spawns background thread via `Arc`-wrapped inner service)

### Files changed (13)
| File | Changes |
|------|---------|
| `htg/src/service.rs` | `BoundingBox`, `PreloadStats`, `preload()`, `scan_tile_files()`, 10 new tests |
| `htg/src/lib.rs` | Re-export `BoundingBox`, `PreloadStats` |
| `htg/Cargo.toml` | Version bump 0.3.4 → 0.3.5 |
| `htg-python/src/lib.rs` | `Arc` wrapping, `PreloadStats` pyclass, `preload()` method |
| `htg-python/python/srtm/__init__.pyi` | Type stubs for `PreloadStats` and `preload()` |
| `htg-python/python/srtm/__init__.py` | `PreloadStats` re-export |
| `htg-python/Cargo.toml` | Version bump 0.3.4 → 0.3.5 |
| `htg-service/src/main.rs` | `HTG_PRELOAD` env var + `parse_preload_bounds()` |
| `README.md`, `htg/README.md`, `htg-python/README.md` | Preload documentation |
| `CLAUDE.md` | Updated features list and env vars table |

Closes #70

## Test plan

- [x] `cargo test -p htg` — 51 tests pass (10 new preload tests)
- [x] `cargo test -p htg-service` — 17 tests pass
- [x] `cargo clippy --workspace` — no warnings
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)