### PR TITLE
perf: eliminate per-query heap allocation and optimize batch lookups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "htg"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "flate2",
  "geojson",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "htg-python"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "htg",
  "pyo3",

--- a/htg-python/Cargo.toml
+++ b/htg-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htg-python"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 authors = ["Pedro Sánchez Martínez <pedrosanzmtz@users.noreply.github.com>"]
 description = "Python bindings for htg SRTM elevation library"

--- a/htg/Cargo.toml
+++ b/htg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htg"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 authors = ["Pedro Sánchez Martínez <pedrosanzmtz@users.noreply.github.com>"]
 description = "High-performance SRTM elevation data library"

--- a/htg/src/filename.rs
+++ b/htg/src/filename.rs
@@ -12,6 +12,42 @@
 //!
 //! The filename represents the **southwest corner** of the 1° × 1° tile.
 
+/// Convert integer tile coordinates to an SRTM `.hgt` filename.
+///
+/// This is the core formatting function used internally. It takes the
+/// already-floored integer coordinates and produces the filename string.
+///
+/// # Arguments
+///
+/// * `lat_int` - Floored latitude (e.g., 35 for lat 35.5, -13 for lat -12.3)
+/// * `lon_int` - Floored longitude (e.g., 138 for lon 138.7, -78 for lon -77.1)
+///
+/// # Returns
+///
+/// The filename (e.g., "N35E138.hgt")
+///
+/// # Examples
+///
+/// ```
+/// use htg::filename::coords_to_filename;
+///
+/// assert_eq!(coords_to_filename(35, 138), "N35E138.hgt");
+/// assert_eq!(coords_to_filename(-13, -78), "S13W078.hgt");
+/// assert_eq!(coords_to_filename(0, -1), "N00W001.hgt");
+/// ```
+pub fn coords_to_filename(lat_int: i32, lon_int: i32) -> String {
+    let lat_prefix = if lat_int >= 0 { 'N' } else { 'S' };
+    let lon_prefix = if lon_int >= 0 { 'E' } else { 'W' };
+
+    format!(
+        "{}{:02}{}{:03}.hgt",
+        lat_prefix,
+        lat_int.abs(),
+        lon_prefix,
+        lon_int.abs()
+    )
+}
+
 /// Convert latitude and longitude to an SRTM `.hgt` filename.
 ///
 /// # Arguments
@@ -33,19 +69,7 @@
 /// assert_eq!(lat_lon_to_filename(0.5, -0.5), "N00W001.hgt");
 /// ```
 pub fn lat_lon_to_filename(lat: f64, lon: f64) -> String {
-    let lat_int = lat.floor() as i32;
-    let lon_int = lon.floor() as i32;
-
-    let lat_prefix = if lat_int >= 0 { 'N' } else { 'S' };
-    let lon_prefix = if lon_int >= 0 { 'E' } else { 'W' };
-
-    format!(
-        "{}{:02}{}{:03}.hgt",
-        lat_prefix,
-        lat_int.abs(),
-        lon_prefix,
-        lon_int.abs()
-    )
+    coords_to_filename(lat.floor() as i32, lon.floor() as i32)
 }
 
 /// Parse an SRTM filename to extract the base coordinates.
@@ -126,6 +150,15 @@ pub fn is_valid_srtm_coord(lat: f64, lon: f64) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_coords_to_filename() {
+        assert_eq!(coords_to_filename(35, 138), "N35E138.hgt");
+        assert_eq!(coords_to_filename(-13, -78), "S13W078.hgt");
+        assert_eq!(coords_to_filename(0, 0), "N00E000.hgt");
+        assert_eq!(coords_to_filename(0, -1), "N00W001.hgt");
+        assert_eq!(coords_to_filename(-60, -180), "S60W180.hgt");
+    }
 
     #[test]
     fn test_positive_coords() {


### PR DESCRIPTION
## Summary

Closes #73

- **Cache key changed from `String` to `(i32, i32)`** — eliminates a `format!()` heap allocation on every cache hit (the hot path), replacing it with a zero-allocation integer tuple lookup
- **Added `coords_to_filename()` helper** — filename string is now only generated on cache miss when disk I/O is needed
- **Tile-grouped batch processing** — `get_elevations_batch()`, `get_elevations_batch_floor()`, and `get_elevations_batch_interpolated()` now group coordinates by tile and load each unique tile once (1 cache lookup per tile, not per coordinate)
- **Bump htg and htg-python to v0.3.6** — no public API changes, internal optimization only

## Test plan

- [x] `cargo test -p htg` — all 52 unit tests + 3 doc tests pass
- [x] `cargo test -p htg-service` — all 3 unit + 14 integration tests pass
- [x] `cargo test` — full workspace (92 tests) passes
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)