### PR TITLE
fix: rename Python package from srtm to srtm-rs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,7 +215,7 @@ jobs:
 
             **Python:**
             ```bash
-            pip install srtm==${{ needs.check-version.outputs.version }}
+            pip install srtm-rs==${{ needs.check-version.outputs.version }}
             ```
 
             **Docker:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,7 @@ htg/                            # Workspace root
 │           ├── batch.rs        # CSV/GeoJSON batch processing
 │           ├── info.rs         # Tile information display
 │           └── list.rs         # List available tiles
-└── htg-python/                 # Python bindings (PyPI: srtm)
+└── htg-python/                 # Python bindings (PyPI: srtm-rs)
     ├── Cargo.toml
     ├── pyproject.toml
     ├── src/
@@ -169,7 +169,7 @@ htg/                            # Workspace root
 - **htg** library → crates.io
 - **htg-service** binary → DockerHub
 - **htg-cli** binary → crates.io (cargo install)
-- **htg-python** (srtm) → PyPI
+- **htg-python** (srtm-rs) → PyPI
 
 ## API Endpoints
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ htg/
 │       ├── main.rs       # CLI entry point
 │       └── commands/     # Command implementations
 │
-└── htg-python/       # Python bindings (PyPI: srtm)
+└── htg-python/       # Python bindings (PyPI: srtm-rs)
     ├── src/lib.rs        # PyO3 bindings
-    └── python/srtm/      # Python package + type stubs
+    └── python/srtm_rs/   # Python package + type stubs
 ```
 
 ## Quick Start
@@ -396,20 +396,20 @@ htg --data-dir /path/to/srtm --cache-size 50 --auto-download query --lat 35.5 --
 
 ## Python Bindings
 
-The `srtm` Python package provides native bindings via PyO3. Supports Python 3.12+.
+The `srtm-rs` Python package provides native bindings via PyO3. Supports Python 3.12+.
 
 ### Installation
 
 ```bash
-pip install srtm
+pip install srtm-rs
 ```
 
 ### Usage
 
 ```python
-import srtm
+import srtm_rs
 
-service = srtm.SrtmService("/path/to/srtm", cache_size=100)
+service = srtm_rs.SrtmService("/path/to/srtm", cache_size=100)
 
 # Single query — returns None for void/missing data
 elevation = service.get_elevation(35.3606, 138.7274)

--- a/benchmarks/benchmark_all_libraries.py
+++ b/benchmarks/benchmark_all_libraries.py
@@ -38,25 +38,9 @@ class LibraryResult:
 def benchmark_htg_python(data_dir: str, n_queries: int = 1000) -> LibraryResult:
     """Benchmark htg-python (Rust + PyO3)."""
     try:
-        # Uninstall srtm.py temporarily to avoid namespace conflict
-        import subprocess
-        subprocess.run(["uv", "pip", "uninstall", "srtm.py"],
-                      capture_output=True, check=False)
+        import srtm_rs
 
-        # Clear module cache
-        if 'srtm' in sys.modules:
-            del sys.modules['srtm']
-
-        import srtm
-
-        # Verify it's the right module
-        if not hasattr(srtm, 'SrtmService'):
-            return LibraryResult(
-                "htg-python", "Rust + PyO3", 0, 0, 0, False,
-                "Wrong srtm module imported"
-            )
-
-        service = srtm.SrtmService(data_dir, cache_size=100)
+        service = srtm_rs.SrtmService(data_dir, cache_size=100)
 
         # Warmup
         _ = service.get_elevation(35.3606, 138.7274)
@@ -81,23 +65,7 @@ def benchmark_htg_python(data_dir: str, n_queries: int = 1000) -> LibraryResult:
 def benchmark_srtm_py(data_dir: str, n_queries: int = 1000) -> LibraryResult:
     """Benchmark srtm.py (pure Python)."""
     try:
-        # Reinstall srtm.py
-        import subprocess
-        subprocess.run(["uv", "pip", "install", "srtm.py"],
-                      capture_output=True, check=False)
-
-        # Clear module cache
-        if 'srtm' in sys.modules:
-            del sys.modules['srtm']
-
         import srtm
-
-        # Verify it's the right module
-        if not hasattr(srtm, 'get_data'):
-            return LibraryResult(
-                "srtm.py", "Pure Python", 0, 0, 0, False,
-                "Wrong srtm module imported - htg-python detected"
-            )
 
         elevation_data = srtm.get_data(local_cache_dir=data_dir)
 

--- a/benchmarks/benchmark_all_three.py
+++ b/benchmarks/benchmark_all_three.py
@@ -38,25 +38,9 @@ class LibraryResult:
 def benchmark_htg_python(data_dir: str, n_queries: int = 1000) -> LibraryResult:
     """Benchmark htg-python (Rust + PyO3)."""
     try:
-        # Uninstall srtm.py temporarily to avoid namespace conflict
-        import subprocess
-        subprocess.run(["uv", "pip", "uninstall", "srtm.py"],
-                      capture_output=True, check=False)
+        import srtm_rs
 
-        # Clear module cache
-        if 'srtm' in sys.modules:
-            del sys.modules['srtm']
-
-        import srtm
-
-        # Verify it's the right module
-        if not hasattr(srtm, 'SrtmService'):
-            return LibraryResult(
-                "htg-python", "Rust + PyO3", 0, 0, 0, False,
-                "Wrong srtm module imported"
-            )
-
-        service = srtm.SrtmService(data_dir, cache_size=100)
+        service = srtm_rs.SrtmService(data_dir, cache_size=100)
 
         # Warmup
         _ = service.get_elevation(35.3606, 138.7274)
@@ -81,23 +65,7 @@ def benchmark_htg_python(data_dir: str, n_queries: int = 1000) -> LibraryResult:
 def benchmark_srtm_py(data_dir: str, n_queries: int = 1000) -> LibraryResult:
     """Benchmark srtm.py (pure Python)."""
     try:
-        # Reinstall srtm.py
-        import subprocess
-        subprocess.run(["uv", "pip", "install", "srtm.py"],
-                      capture_output=True, check=False)
-
-        # Clear module cache
-        if 'srtm' in sys.modules:
-            del sys.modules['srtm']
-
         import srtm
-
-        # Verify it's the right module
-        if not hasattr(srtm, 'get_data'):
-            return LibraryResult(
-                "srtm.py", "Pure Python", 0, 0, 0, False,
-                "Wrong srtm module imported - htg-python detected"
-            )
 
         elevation_data = srtm.get_data(local_cache_dir=data_dir)
 

--- a/benchmarks/benchmark_comparison.py
+++ b/benchmarks/benchmark_comparison.py
@@ -103,16 +103,16 @@ def benchmark_srtm4_startup(data_dir: str) -> float:
 def benchmark_htg_startup(data_dir: str, cache_size: int = 100) -> float:
     """Measure htg import and first query time."""
     # Clear module cache
-    if "srtm" in sys.modules:
-        del sys.modules["srtm"]
+    if "srtm_rs" in sys.modules:
+        del sys.modules["srtm_rs"]
 
     gc.collect()
 
     start = time.perf_counter()
-    import srtm
+    import srtm_rs
 
     # Create service and first query
-    service = srtm.SrtmService(data_dir, cache_size=cache_size)
+    service = srtm_rs.SrtmService(data_dir, cache_size=cache_size)
     lat, lon = TEST_COORDS[0]
     _ = service.get_elevation(lat, lon)
 
@@ -152,7 +152,7 @@ def benchmark_srtm4_memory(data_dir: str, num_tiles: int = 10) -> dict[str, floa
 def benchmark_htg_memory(data_dir: str, num_tiles: int = 10, cache_size: int = 100) -> dict[str, float]:
     """Measure htg memory usage."""
     try:
-        import srtm
+        import srtm_rs
     except ImportError:
         console.print("[yellow]htg not installed, skipping[/yellow]")
         return {"baseline_mb": 0, "after_queries_mb": 0, "delta_mb": 0}
@@ -160,7 +160,7 @@ def benchmark_htg_memory(data_dir: str, num_tiles: int = 10, cache_size: int = 1
     gc.collect()
     baseline_mem = get_process_memory_mb()
 
-    service = srtm.SrtmService(data_dir, cache_size=cache_size)
+    service = srtm_rs.SrtmService(data_dir, cache_size=cache_size)
 
     # Query multiple tiles
     for i in range(num_tiles):
@@ -223,11 +223,11 @@ def benchmark_srtm4_latency(data_dir: str, n_queries: int = 1000) -> dict[str, f
 def benchmark_htg_latency(data_dir: str, n_queries: int = 1000, cache_size: int = 100) -> dict[str, float]:
     """Measure htg query latency."""
     try:
-        import srtm
+        import srtm_rs
     except ImportError:
         return {"mean_ms": 0, "p50_ms": 0, "p95_ms": 0, "p99_ms": 0, "min_ms": 0, "max_ms": 0}
 
-    service = srtm.SrtmService(data_dir, cache_size=cache_size)
+    service = srtm_rs.SrtmService(data_dir, cache_size=cache_size)
 
     # Warm up (query first tile)
     lat, lon = TEST_COORDS[0]
@@ -296,11 +296,11 @@ def benchmark_srtm4_throughput(data_dir: str, duration_seconds: int = 5) -> dict
 def benchmark_htg_throughput(data_dir: str, duration_seconds: int = 5, cache_size: int = 100) -> dict[str, float]:
     """Measure htg throughput (single-threaded)."""
     try:
-        import srtm
+        import srtm_rs
     except ImportError:
         return {"queries_per_second": 0, "total_queries": 0}
 
-    service = srtm.SrtmService(data_dir, cache_size=cache_size)
+    service = srtm_rs.SrtmService(data_dir, cache_size=cache_size)
 
     # Warm up
     lat, lon = TEST_COORDS[0]
@@ -381,10 +381,10 @@ def run_benchmarks(data_dir: str, output_file: str | None = None):
         has_srtm4 = False
 
     try:
-        import srtm
+        import srtm_rs
         has_htg = True
     except ImportError:
-        console.print("[yellow]Warning: htg not installed. Install with: pip install htg[/yellow]")
+        console.print("[yellow]Warning: htg not installed. Install with: pip install srtm-rs[/yellow]")
         console.print("[yellow]Or install locally: cd htg-python && pip install -e .[/yellow]")
         has_htg = False
 

--- a/htg-python/Cargo.toml
+++ b/htg-python/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/pedrosanzmtz/htg"
 readme = "README.md"
 
 [lib]
-name = "srtm"
+name = "srtm_rs"
 crate-type = ["cdylib"]
 
 [dependencies]

--- a/htg-python/README.md
+++ b/htg-python/README.md
@@ -1,6 +1,6 @@
-# srtm - High-performance SRTM Elevation Library
+# srtm-rs - High-performance SRTM Elevation Library
 
-[![PyPI](https://img.shields.io/pypi/v/srtm.svg)](https://pypi.org/project/srtm/)
+[![PyPI](https://img.shields.io/pypi/v/srtm-rs.svg)](https://pypi.org/project/srtm-rs/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 **Ultra-fast SRTM elevation queries in Python.** Built with Rust, delivering **3.5x faster** performance than the most popular Python SRTM library.
@@ -10,7 +10,7 @@ Python bindings for the [htg](https://github.com/pedrosanzmtz/htg) Rust library,
 ## Installation
 
 ```bash
-pip install srtm
+pip install srtm-rs
 ```
 
 Prebuilt wheels are available for Python 3.12+ on Linux (x86_64, aarch64), macOS (Apple Silicon, x86_64), and Windows (x86_64).
@@ -18,10 +18,10 @@ Prebuilt wheels are available for Python 3.12+ on Linux (x86_64, aarch64), macOS
 ## Quick Start
 
 ```python
-import srtm
+import srtm_rs
 
 # Create service with up to 100 cached tiles
-service = srtm.SrtmService("/path/to/srtm", cache_size=100)
+service = srtm_rs.SrtmService("/path/to/srtm", cache_size=100)
 
 # Query elevation (Mount Fuji)
 # Returns None for void data or missing tiles
@@ -45,9 +45,9 @@ print(f"Cache hit rate: {stats.hit_rate:.1%}")
 If you're migrating from [srtm.py](https://github.com/tkrajina/srtm.py), use `rounding="floor"` for exact value parity. srtm.py uses `math.floor()` for grid cell selection, while htg defaults to `round()` (true nearest-neighbor). The difference is typically 1-3 meters at grid cell boundaries.
 
 ```python
-import srtm
+import srtm_rs
 
-service = srtm.SrtmService("/path/to/srtm", cache_size=100)
+service = srtm_rs.SrtmService("/path/to/srtm", cache_size=100)
 
 # Default: true nearest-neighbor (round)
 elevation = service.get_elevation(33.3448, -96.1592)  # 190
@@ -64,9 +64,9 @@ elevations = service.get_elevations_batch(coords, default=0, rounding="floor")
 Query multiple coordinates efficiently in a single call:
 
 ```python
-import srtm
+import srtm_rs
 
-service = srtm.SrtmService("/path/to/srtm", cache_size=100)
+service = srtm_rs.SrtmService("/path/to/srtm", cache_size=100)
 
 coords = [
     (35.3606, 138.7274),  # Mount Fuji
@@ -84,9 +84,9 @@ print(elevations)  # [3776, 8752, 3148]
 Warm the cache at startup to avoid cold-start latency (useful when tiles are on NFS):
 
 ```python
-import srtm
+import srtm_rs
 
-service = srtm.SrtmService("/path/to/srtm", cache_size=100)
+service = srtm_rs.SrtmService("/path/to/srtm", cache_size=100)
 
 # Preload all tiles
 stats = service.preload()
@@ -105,18 +105,18 @@ service.preload(blocking=False)
 ## Utility Functions
 
 ```python
-import srtm
+import srtm_rs
 
 # Convert coordinates to filename
-filename = srtm.lat_lon_to_filename(35.5, 138.7)
+filename = srtm_rs.lat_lon_to_filename(35.5, 138.7)
 print(filename)  # "N35E138.hgt"
 
 # Parse filename to coordinates
-coords = srtm.filename_to_lat_lon("N35E138.hgt")
+coords = srtm_rs.filename_to_lat_lon("N35E138.hgt")
 print(coords)  # (35, 138)
 
 # Void value constant
-print(srtm.VOID_VALUE)  # -32768
+print(srtm_rs.VOID_VALUE)  # -32768
 ```
 
 ## SRTM Data
@@ -129,15 +129,15 @@ Both `.hgt` and `.hgt.zip` files are supported. ZIP files are transparently extr
 
 ## Performance
 
-srtm delivers **exceptional performance** through its Rust core and PyO3 bindings, significantly outperforming traditional Python SRTM libraries.
+srtm-rs delivers **exceptional performance** through its Rust core and PyO3 bindings, significantly outperforming traditional Python SRTM libraries.
 
 ### Benchmarks vs Popular Python Libraries
 
 Comparison using **local .hgt files only** (fair, apples-to-apples test):
 
-| Library | Implementation | Per Query | Throughput | vs srtm |
-|---------|----------------|-----------|------------|---------|
-| **srtm** | Rust + PyO3 | **0.41 us** | **2,419,110 q/s** | 1.0x (baseline) |
+| Library | Implementation | Per Query | Throughput | vs srtm-rs |
+|---------|----------------|-----------|------------|------------|
+| **srtm-rs** | Rust + PyO3 | **0.41 us** | **2,419,110 q/s** | 1.0x (baseline) |
 | **[srtm.py](https://github.com/tkrajina/srtm.py)** | Pure Python (256 stars) | 1.43 us | 697,654 q/s | **3.5x slower** |
 | **[srtm4](https://github.com/centreborelli/srtm4)** | Python + C++ subprocess | 99,630 us | 10 q/s | **241,017x slower** |
 
@@ -159,8 +159,8 @@ Comparison using **local .hgt files only** (fair, apples-to-apples test):
 ### Real-World Performance
 
 ```python
-import srtm
-service = srtm.SrtmService("/path/to/data", cache_size=100)
+import srtm_rs
+service = srtm_rs.SrtmService("/path/to/data", cache_size=100)
 
 # Single query: ~0.4 microseconds (sub-millisecond!)
 elevation = service.get_elevation(35.3606, 138.7274)

--- a/htg-python/pyproject.toml
+++ b/htg-python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["maturin>=1.4,<2.0"]
 build-backend = "maturin"
 
 [project]
-name = "srtm"
+name = "srtm-rs"
 dynamic = ["version"]
 description = "High-performance SRTM elevation data library"
 readme = "README.md"
@@ -35,4 +35,4 @@ dev = ["pytest", "maturin"]
 [tool.maturin]
 features = ["pyo3/extension-module"]
 python-source = "python"
-module-name = "srtm"
+module-name = "srtm_rs"

--- a/htg-python/python/srtm_rs/__init__.py
+++ b/htg-python/python/srtm_rs/__init__.py
@@ -1,6 +1,6 @@
 # The native extension module is imported directly by maturin
 # This file just ensures the package is recognized and provides type hints
-from srtm.srtm import (  # type: ignore[import]
+from srtm_rs.srtm_rs import (  # type: ignore[import]
     CacheStats as CacheStats,
     PreloadStats as PreloadStats,
     SrtmService as SrtmService,

--- a/htg-python/python/srtm_rs/__init__.pyi
+++ b/htg-python/python/srtm_rs/__init__.pyi
@@ -1,4 +1,4 @@
-"""Type stubs for srtm - High-performance SRTM elevation library."""
+"""Type stubs for srtm_rs - High-performance SRTM elevation library."""
 
 from typing import List, Optional, Tuple
 

--- a/htg-python/src/lib.rs
+++ b/htg-python/src/lib.rs
@@ -358,18 +358,18 @@ fn filename_to_lat_lon(filename: &str) -> Option<(i32, i32)> {
     htg_lib::filename::filename_to_lat_lon(filename)
 }
 
-/// SRTM - High-performance SRTM elevation library.
+/// srtm_rs - High-performance SRTM elevation library.
 ///
 /// This module provides Python bindings for the htg Rust library,
 /// enabling fast elevation queries from SRTM .hgt files.
 ///
 /// Example:
-///     >>> import srtm
-///     >>> service = srtm.SrtmService("/path/to/srtm", cache_size=100)
+///     >>> import srtm_rs
+///     >>> service = srtm_rs.SrtmService("/path/to/srtm", cache_size=100)
 ///     >>> elevation = service.get_elevation(35.3606, 138.7274)
 ///     >>> print(f"Mount Fuji: {elevation}m")
 #[pymodule]
-fn srtm(m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn srtm_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<SrtmService>()?;
     m.add_class::<CacheStats>()?;
     m.add_class::<PreloadStats>()?;


### PR DESCRIPTION
## Summary
- Renames PyPI package from `srtm` to `srtm-rs` and Python import from `srtm` to `srtm_rs` to resolve namespace conflict with the established `srtm.py` package (tkrajina/srtm.py)
- Updates all documentation, benchmarks, and CI workflows to use the new package name
- Simplifies benchmark scripts by removing namespace conflict workarounds that are no longer needed

Closes #78

## Test plan
- [x] `cargo test` — all tests pass
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt --check` — formatting OK
- [x] Grep confirms no stale `import srtm` / `pip install srtm` references (only srtm.py competitor references remain)
- [ ] Verify `maturin develop` builds correctly with new module name
- [ ] Verify `import srtm_rs` works in Python after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)